### PR TITLE
Update config.yaml 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,6 @@ properties:
   regex:
     title: Regex
     type: string
-    format: regex
   annotate:
     title: Annotate
     type: boolean


### PR DESCRIPTION
Gettting rid of format argument for regex because it forces JavaScript-style regex formatting onto regex being implemented in Python